### PR TITLE
Update to use non-forked go-simplejson

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ not explicitly defined in the struct.
 
 json-lossless builds off of bit.ly's excellent
 [go-simplejson](https://github.com/bitly/go-simplejson) package.
-However, until bitly/go-simplejson#17 is merged, it requires my
-fork of the package.
 
 json-lossless is experimental and probably doesn't work in a lot
 of cases.  Pull requests very welcome.

--- a/lossless.go
+++ b/lossless.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/joeshaw/go-simplejson"
+	"github.com/bitly/go-simplejson"
 )
 
 // The JSON type contains the state of the decoded data.  Embed this


### PR DESCRIPTION
It seems like the commit from https://github.com/bitly/go-simplejson/pull/17 was merged in commit: https://github.com/bitly/go-simplejson/commit/7f4699f47869d2c308a78239e255f63eec927ec0.

This is just to change the import to use the non-forked version.